### PR TITLE
fix(composer): can be used with guzzle ^7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   },
   "require": {
     "php": ">=7.0",
-    "guzzlehttp/guzzle": "^6.3"
+    "guzzlehttp/guzzle": "^6.3 || ^7.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^7",


### PR DESCRIPTION
Данный PR относится к #1 и включает в себя исправление версии guzzle с сохранением обратной совместимости. 

Было:
```composer
     "guzzlehttp/guzzle": "^6.3"
```
Стало:
```composer
     "guzzlehttp/guzzle": "^6.3 || ^7.0"
```
Таким образом, пакет можно использовать как со старой, так и текущей версией guzzle. 

Работа библиотеки протестирована вручную, проблем не обнаружено. Юнит-тесты побоялся запускать, т.к. там присутствуют unsafe операции.

Буду признателен, если примете мой PR. 